### PR TITLE
Investment calculator

### DIFF
--- a/src/app/api/calculate/route.test.ts
+++ b/src/app/api/calculate/route.test.ts
@@ -62,6 +62,13 @@ describe('POST /api/calculate', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 when analysis is missing nested objects', async () => {
+    const res = await POST(makeRequest({ analysis: { financials: {} } }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/malformed/i);
+  });
+
   it('returns 200 with valid analysis and computed metrics', async () => {
     const res = await POST(makeRequest({ analysis: validAnalysis }));
     expect(res.status).toBe(200);

--- a/src/app/api/calculate/route.ts
+++ b/src/app/api/calculate/route.ts
@@ -11,6 +11,16 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  if (
+    typeof body.analysis !== 'object' ||
+    !body.analysis.financials ||
+    !body.analysis.property ||
+    !body.analysis.protocols ||
+    !body.analysis.wirtschaftsplan
+  ) {
+    return NextResponse.json({ error: 'analysis is malformed' }, { status: 400 });
+  }
+
   const analysis: AnalysisResult = body.analysis;
   const assumptions: Partial<MortgageAssumptions> | undefined = body.assumptions;
 

--- a/src/lib/__tests__/calculator.test.ts
+++ b/src/lib/__tests__/calculator.test.ts
@@ -253,8 +253,9 @@ describe('computeMetrics', () => {
     // totalAcqCost = 278000
     expect(metrics.totalAcquisitionCost).toBe(278000);
 
-    // netRentalYield: (10800 - 4200 - 600) / 278000 * 100 = 2.158...
-    expect(metrics.netRentalYield).toBeCloseTo(2.158, 2);
+    // netRentalYield: (10800 - 4200 - 0) / 278000 * 100 = 2.374...
+    // hausgeld is inclusive of ruecklage per WEG convention, so nonRecoverableCosts = 0
+    expect(metrics.netRentalYield).toBeCloseTo(2.374, 2);
 
     // Loan = 250000 * 0.80 = 200000, 3.5%, 25 years => ~1001.25
     expect(metrics.monthlyMortgagePayment).toBeCloseTo(1001.25, 0);

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -240,17 +240,19 @@ export function computeMetrics(
   }
 
   // netRentalYield
+  // Hausgeld is the total monthly HOA fee inclusive of Instandhaltungsrücklage
+  // (reserve fund) per standard WEG accounting, so ruecklage is NOT passed
+  // separately as nonRecoverableCosts to avoid double-counting.
   let computedNetYield: number | null = null;
   if (
     monthlyRent != null &&
     financials.hausgeld != null &&
-    financials.ruecklage != null &&
     computedTotalAcqCost != null
   ) {
     computedNetYield = netRentalYield(
       monthlyRent * 12,
       financials.hausgeld * 12,
-      financials.ruecklage * 12,
+      0,
       computedTotalAcqCost,
     );
   }


### PR DESCRIPTION
## feature: realty-check-4

## Description

Compute key investment metrics from the LLM-extracted data — this replaces the spreadsheet calculation the real estate advisor currently does manually.

## Requirements

- Utility module `src/lib/calculator.ts` with pure functions for:
  - **Gross rental yield**: (annual rent / purchase price) × 100
  - **Net rental yield**: ((annual rent - annual Hausgeld - non-recoverable costs) / total acquisition cost) × 100
  - **Total acquisition cost**: purchase price + Grunderwerbsteuer + Notar + Makler
  - **Monthly cash flow**: rent - Hausgeld - mortgage payment (configurable interest rate + amortization)
  - **Price per sqm**: purchase price / living area
  - **Renovation reserve adequacy**: compare Rücklage to upcoming renovation costs from protocols
  - **Break-even analysis**: years until investment is cash-flow positive
- API route `POST /api/calculate` — takes analysis JSON, returns computed metrics
- All calculations must be unit-tested
- Support configurable assumptions: mortgage rate (default 3.5%), down payment (default 20%), loan term (default 25 years)

## Tech notes

- Pure TypeScript functions, no external dependencies needed
- Add vitest for testing: `npm install -D vitest`
- Write tests in `src/lib/__tests__/calculator.test.ts`

Closes https://github.com/bing107/realty-check/issues/4