### PR TITLE
Market price comparison via ImmoScout Atlas

### DIFF
--- a/src/app/api/compare/route.test.ts
+++ b/src/app/api/compare/route.test.ts
@@ -1,6 +1,12 @@
 /** @jest-environment node */
 import { POST } from './route';
 import { NextRequest } from 'next/server';
+import { lookupCityData } from '../../../lib/market-data';
+
+jest.mock('../../../lib/market-data', () => {
+  const actual = jest.requireActual('../../../lib/market-data');
+  return { ...actual, lookupCityData: jest.fn(actual.lookupCityData) };
+});
 
 function makeRequest(body: unknown) {
   return new NextRequest('http://localhost/api/compare', {
@@ -149,24 +155,24 @@ describe('POST /api/compare', () => {
     expect(data.error).toBeDefined();
   });
 
-  // 14. Returns 400 when price is NaN
-  it('returns 400 when price is NaN', async () => {
+  // 14. NaN becomes null via JSON.stringify, rejected by typeof !== 'number'
+  it('returns 400 when price is NaN (serialized as null)', async () => {
     const res = await POST(makeRequest({ address: 'Berlin', price: NaN, sqm: 75 }));
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toMatch(/price/i);
   });
 
-  // 15. Returns 400 when price is Infinity
-  it('returns 400 when price is Infinity', async () => {
+  // 15. Infinity becomes null via JSON.stringify, rejected by typeof !== 'number'
+  it('returns 400 when price is Infinity (serialized as null)', async () => {
     const res = await POST(makeRequest({ address: 'Berlin', price: Infinity, sqm: 75 }));
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toMatch(/price/i);
   });
 
-  // 16. Returns 400 when sqm is NaN
-  it('returns 400 when sqm is NaN', async () => {
+  // 16. NaN becomes null via JSON.stringify, rejected by typeof !== 'number'
+  it('returns 400 when sqm is NaN (serialized as null)', async () => {
     const res = await POST(makeRequest({ address: 'Berlin', price: 300000, sqm: NaN }));
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -247,23 +253,22 @@ describe('POST /api/compare', () => {
   // 25. Cache TTL expiry: expired entries are not returned
   it('does not return expired cache entries', async () => {
     jest.useFakeTimers();
+    const mock = lookupCityData as jest.Mock;
+    mock.mockClear();
     try {
       const body = { address: 'Freiburg Altstadt', price: 412500, sqm: 75 };
 
       const res1 = await POST(makeRequest(body));
       expect(res1.status).toBe(200);
-      const data1 = await res1.json();
+      expect(mock).toHaveBeenCalledTimes(1);
 
       // Advance time past the 1-hour TTL
       jest.advanceTimersByTime(60 * 60 * 1000 + 1);
 
       const res2 = await POST(makeRequest(body));
       expect(res2.status).toBe(200);
-      const data2 = await res2.json();
-
-      // Both should still produce valid results (just not from a stale cache)
-      expect(data2.city).toBe('Freiburg');
-      expect(data2.pricePerSqm).toBe(data1.pricePerSqm);
+      // lookupCityData must be called again, proving the cache entry expired
+      expect(mock).toHaveBeenCalledTimes(2);
     } finally {
       jest.useRealTimers();
     }
@@ -286,8 +291,8 @@ describe('POST /api/compare', () => {
     expect(data.avgPricePerSqm).toBe(5500);
   });
 
-  // 28. Returns 400 when price is -Infinity
-  it('returns 400 when price is -Infinity', async () => {
+  // 28. -Infinity becomes null via JSON.stringify, rejected by typeof !== 'number'
+  it('returns 400 when price is -Infinity (serialized as null)', async () => {
     const res = await POST(makeRequest({ address: 'Berlin', price: -Infinity, sqm: 75 }));
     expect(res.status).toBe(400);
   });

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -20,6 +20,7 @@ interface ComparisonResult {
 // ---------------------------------------------------------------------------
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const MAX_CACHE_SIZE = 1000;
 
 const cache = new Map<string, { result: ComparisonResult; expiresAt: number }>();
 
@@ -34,6 +35,10 @@ function getCached(key: string): ComparisonResult | null {
 }
 
 function setCache(key: string, result: ComparisonResult): void {
+  if (cache.size >= MAX_CACHE_SIZE) {
+    // evict oldest entry
+    cache.delete(cache.keys().next().value!);
+  }
   cache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 

--- a/src/lib/market-data.ts
+++ b/src/lib/market-data.ts
@@ -95,7 +95,7 @@ function normalCDF(z: number): number {
 export function lookupCityData(address: string): { data: CityMarketData; matched: string } {
   const normalized = address.toLowerCase().trim();
 
-  // Check canonical city keys (longest first to avoid partial matches like "essen" in "gelsenkirchen")
+  // Check canonical city keys longest-first so e.g. 'neuessen' resolves before 'essen'
   const canonicalKeys = Object.keys(CITY_MARKET_DATA).filter((k) => k !== 'default');
   canonicalKeys.sort((a, b) => b.length - a.length);
 


### PR DESCRIPTION
## feature: realty-check-5

## Description

Pull comparable market data to benchmark the listing price against local averages. Compare the property's price-per-sqm to the area average.

## Requirements

- Research how to get price data from ImmoScout24 Atlas or similar public sources (immowelt, Bodenrichtwert)
- If no public API is available, use web scraping or a static reference dataset as fallback
- API route `POST /api/compare` — takes property address + price + sqm, returns:
  - Average price-per-sqm in the area (PLZ or district level)
  - Price range (min/max) for comparable properties
  - Percentile: where this property falls in the local market
  - Price trend (if data available): rising/stable/falling
- Return comparison data as structured JSON
- Cache results to avoid repeated lookups

## Tech notes

- If scraping, respect robots.txt and rate limits
- Fallback: hardcode a reference dataset of German city price-per-sqm averages as a starting point
- The LLM analysis already extracts address and price — use those as input

Closes https://github.com/bing107/realty-check/issues/5